### PR TITLE
fingerprint from published debug.keystore

### DIFF
--- a/static/.well-known/assetlinks.json
+++ b/static/.well-known/assetlinks.json
@@ -8,7 +8,7 @@
       "namespace": "android_app",
       "package_name": "app.kokio",
       "sha256_cert_fingerprints": [
-        "68:5B:86:CB:45:99:45:20:23:31:62:28:0E:B3:4D:C7:4A:22:11:0C:08:0D:ED:04:22:A2:5F:ED:47:ED:B6:35"
+        "48:3C:51:50:74:39:61:6B:7E:76:E7:A0:0D:2C:C6:7D:0F:C6:58:4F:C0:17:51:15:CA:79:BE:92:C4:CD:18:65"
       ]
     }
   }


### PR DESCRIPTION
Updated fingerprint to published debug.keystore in https://github.com/Blockchain-Powered-eSIM/Kokio/blob/passkey-kit/debug.keystore